### PR TITLE
Fix %name, translation

### DIFF
--- a/github_contributions.csv
+++ b/github_contributions.csv
@@ -1,1 +1,1 @@
-Mageplaza,Mageplaza
+"%name,","%name,",module,Magento_GiftCard


### PR DESCRIPTION
%name is the name of a variable. It is probably a bug in magento to use a translate block for it anyway, but the name of the variable must not be changed in a translation string. In the current version of mageplaza/magento-2-finnish-language-pack/fi_FI.csv this is translated as `"%name,","%name,",module,Magento_GiftCard`, which breaks email templates that use `{{trans "%name," ...`